### PR TITLE
[Bug #13] temporary fix: let initial inputs at least match one key for prompt.

### DIFF
--- a/app-backend/app_gateway.py
+++ b/app-backend/app_gateway.py
@@ -65,7 +65,7 @@ class AppGateway(Gateway):
                     params[id]['max_new_tokens'] = params[id]['max_tokens']
                     llm_parameters = LLMParams(**params[id])
             result_dict, runtime_graph = await self.megaservice.schedule(
-                initial_inputs={'text': prompt},
+                initial_inputs={'query':prompt, 'text': prompt},
                 llm_parameters=llm_parameters,
                 params=params,
             )


### PR DESCRIPTION
fixing key not found in initial input for tgi, as the prompt key is different with tei.
This should be a temporary fixed until a solution for standardized I/O has been defined for different microservices that have different keys besides these two.